### PR TITLE
Revert "Revert "Bump certifi from 2020.4.5.1 to 2023.7.22""

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.11.1
 bleach==3.1.4
 bleach-whitelist==0.0.11
-certifi==2020.4.5.1
+certifi==2023.7.22
 cffi==1.15.1
 chardet==3.0.4
 cryptography==42.0.5


### PR DESCRIPTION
Reverts hmcts/incident-response-api#115
Attempting to fix: [DTSPO-17544](https://tools.hmcts.net/jira/browse/DTSPO-17544) but wasn't the source of the issue