### PR TITLE
Revert "Update dependency Django to v2.2.28 [SECURITY]"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ certifi==2024.7.4
 cffi==1.16.0
 chardet==3.0.4
 cryptography==42.0.8
-Django==2.2.28
+Django==2.2.9
 django-after-response==0.2.2
 django-bootstrap4==22.1
 django-health-check==3.18.3


### PR DESCRIPTION
Reverts hmcts/incident-response-api#130

Trying to fix errors in the pods